### PR TITLE
Remove getElementClass() from BatchAction.

### DIFF
--- a/src/Actions/BatchAction.php
+++ b/src/Actions/BatchAction.php
@@ -45,21 +45,6 @@ abstract class BatchAction extends GridAction
     }
 
     /**
-     * @param bool $dotPrefix
-     *
-     * @return string
-     */
-    public function getElementClass($dotPrefix = true)
-    {
-        return sprintf(
-            '%s%s-%s',
-            $dotPrefix ? '.' : '',
-            $this->parent->getGridBatchName(),
-            $this->id
-        );
-    }
-
-    /**
      * @param Request $request
      *
      * @return mixed


### PR DESCRIPTION
Remove getElementClass() from BatchAction so that custom batch action button has correct class name.