### PR TITLE
Remove reference to unused css file on login page

### DIFF
--- a/config/admin.php
+++ b/config/admin.php
@@ -258,7 +258,7 @@ return [
     | Set a default avatar for newly created users.
     |
     */
-    'default_avatar' => '/vendor/open-admin/open-admin/gfx/user.svg',
+    'default_avatar' => '/vendor/open-admin-org/open-admin/resources/assets/open-admin/gfx/user.svg',
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/assets/open-admin/js/open-admin.js
+++ b/resources/assets/open-admin/js/open-admin.js
@@ -354,7 +354,15 @@ admin.ajax = {
         main.innerHTML = data;
 
         main.querySelectorAll('script').forEach((script) => {
-            eval(script.innerText);
+            var src = script.getAttribute('src');
+            if (src) {
+                script = document.createElement('script');
+                script.type = 'text/javascript';
+                script.src = src;
+                document.getElementById('app').appendChild(script);
+            } else {
+                eval(script.innerText);
+            }
         });
 
         if (!admin.ajax.currenTarget) {

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -25,7 +25,7 @@ class Admin
      *
      * @var string
      */
-    public const VERSION = '1.0.20';
+    public const VERSION = '1.0.25';
 
     /**
      * @var Navbar


### PR DESCRIPTION
In `resources/views/login.blade.php` this `Admin::asset("fontello/css/open-admin.css")` file does not exist so is not needed.