### PR TITLE
Fixed form model method to allow the return of actions form interactor.

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -181,9 +181,9 @@ class Form implements Renderable
     }
 
     /**
-     * @return Model
+     * @return Model|\OpenAdmin\Admin\Actions\Interactor\Form
      */
-    public function model(): Model
+    public function model(): Model|\OpenAdmin\Admin\Actions\Interactor\Form
     {
         return $this->model;
     }

--- a/src/Form.php
+++ b/src/Form.php
@@ -137,7 +137,7 @@ class Form implements Renderable
     /**
      * Create a new form instance.
      *
-     * @param $model
+     * @param          $model
      * @param \Closure $callback
      */
     public function __construct($model, Closure $callback = null)


### PR DESCRIPTION
This fixes #72 

When a form is used in a grid action, the `Form::model()` is returning an `Interactor/Form` instead of an Eloquent model. Changed the method to allow both so the form in a grid action is working again.