### PR TITLE
Unremarked page-link click handler in open-admin-selectable.js.

### DIFF
--- a/resources/assets/open-admin/js/open-admin-selectable.js
+++ b/resources/assets/open-admin/js/open-admin-selectable.js
@@ -121,15 +121,12 @@
                     return false;
                 }
 
-                /*
-                // now handeled through admin.ajax.currentTarget
                 if (event.target.classList.contains('page-link')){
                     load(event.target.getAttribute("href"));
                     event.preventDefault();
                     event.stopPropagation();
                     return false;
                 }
-                */
 
                 if (event.target.tagName == "TD"){
                     event.target.parentNode.querySelector(".form-check-input").click();


### PR DESCRIPTION
Fixes #84 
This will enable the checkbox/record select events after a page change in the select modal list of `$form->belongsToMany`.