### PR TITLE
Use var in load method of Select.php

### DIFF
--- a/src/Form/Field/Select.php
+++ b/src/Form/Field/Select.php
@@ -117,7 +117,7 @@ class Select extends Field
 
         $this->additional_script .= <<<JS
 
-            let elm = document.querySelector("{$this->getElementClassSelector()}");
+            var elm = document.querySelector("{$this->getElementClassSelector()}");
             var lookupTimeout;
             elm.addEventListener('change', function(event) {
                 var query = {$this->choicesObjName()}.getValue().value;


### PR DESCRIPTION
The current implementation uses let to declare variable elm. This causes problems if there are multiple calls to the load method on a single page. For example, if a form needs A loads B and B loads C, each call to load method would add its own declaration of variable elm and the browser throws an error for redeclaration of variable elm. Using var would eliminate the issue.