### PR TITLE
Update seperator (,) to (;) and clean html tags CsvExporter.php

### DIFF
--- a/src/Grid/Exporters/CsvExporter.php
+++ b/src/Grid/Exporters/CsvExporter.php
@@ -173,12 +173,12 @@ class CsvExporter extends AbstractExporter
 
                 // Write title
                 if (empty($titles)) {
-                    fputcsv($handle, $titles = $this->getVisiableTitles());
+                    fputcsv($handle, $titles = $this->getVisiableTitles(), ';'); // Seperator to ";" from "," for title
                 }
 
                 // Write rows
                 foreach ($current as $index => $record) {
-                    fputcsv($handle, $this->getVisiableFields($record, $original[$index]));
+                    fputcsv($handle, $this->getVisiableFields($record, $original[$index]), ';');  // Seperator to ";" from "," for rows
                 }
             });
             fclose($handle);
@@ -254,9 +254,11 @@ class CsvExporter extends AbstractExporter
         }
 
         if (isset($this->columnCallbacks[$column])) {
-            return $this->columnCallbacks[$column]($value, $original);
+            $processedValue = $this->columnCallbacks[$column]($value, $original);
+            // HTML etiketlerini kaldır
+            return strip_tags($processedValue);
         }
-
-        return $value;
+        // HTML etiketlerini kaldır
+        return strip_tags($value);
     }
 }


### PR DESCRIPTION
When exporting via CSV, the comma (,) issue has been fixed and code to change the separator has been added.

At the same time, the HTML tag residue that occurred when exporting was eliminated with "strip_tag".