### PR TITLE
ToolTips added to the button actions for Delete, Edit, and Show.

### DIFF
--- a/src/Grid/Actions/Delete.php
+++ b/src/Grid/Actions/Delete.php
@@ -65,4 +65,33 @@ class Delete extends RowAction
 
         return $this->response()->success($trans['succeeded'])->refresh();
     }
+
+
+    /**
+     * Render row action with a tooltip.
+     *
+     * @return string
+     */
+    public function render() {
+        $linkClass = ($this->parent->getActionClass() != "OpenAdmin\Admin\Grid\Displayers\Actions\Actions") ? 'dropdown-item' : '';
+        $icon = $this->getIcon();
+
+        $tooltip = 'Delete'; //tooltip content
+
+        if ($href = $this->href()) {
+            return "<a href='{$href}' class='{$linkClass}' title='{$tooltip}'>{$icon}<span class='label'>{$this->name()}</span></a>";
+        }
+
+        $this->addScript();
+
+        $attributes = $this->formatAttributes();
+
+        return sprintf(
+            "<a data-_key='%s' href='javascript:void(0);' class='%s {$linkClass}' {$attributes} title='{$tooltip}'>{$icon}<span class='label'>%s</span></a>",
+            $this->getKey(),
+            $this->getElementClass(),
+            $this->asColumn ? $this->display($this->row($this->column->getName())) : $this->name()
+        );
+    }
+
 }

--- a/src/Grid/Actions/Edit.php
+++ b/src/Grid/Actions/Edit.php
@@ -23,4 +23,33 @@ class Edit extends RowAction
     {
         return "{$this->getResource()}/{$this->getKey()}/edit";
     }
+
+
+    /**
+     * Render row action with a tooltip.
+     *
+     * @return string
+     */
+    public function render() {
+        $linkClass = ($this->parent->getActionClass() != "OpenAdmin\Admin\Grid\Displayers\Actions\Actions") ? 'dropdown-item' : '';
+        $icon = $this->getIcon();
+
+        $tooltip = 'Edit'; //tooltip content
+
+        if ($href = $this->href()) {
+            return "<a href='{$href}' class='{$linkClass}' title='{$tooltip}'>{$icon}<span class='label'>{$this->name()}</span></a>";
+        }
+
+        $this->addScript();
+
+        $attributes = $this->formatAttributes();
+
+        return sprintf(
+            "<a data-_key='%s' href='javascript:void(0);' class='%s {$linkClass}' {$attributes} title='{$tooltip}'>{$icon}<span class='label'>%s</span></a>",
+            $this->getKey(),
+            $this->getElementClass(),
+            $this->asColumn ? $this->display($this->row($this->column->getName())) : $this->name()
+        );
+    }
+
 }

--- a/src/Grid/Actions/Show.php
+++ b/src/Grid/Actions/Show.php
@@ -23,4 +23,33 @@ class Show extends RowAction
     {
         return "{$this->getResource()}/{$this->getKey()}";
     }
+
+
+    /**
+     * Render row action with a tooltip.
+     *
+     * @return string
+     */
+    public function render() {
+        $linkClass = ($this->parent->getActionClass() != "OpenAdmin\Admin\Grid\Displayers\Actions\Actions") ? 'dropdown-item' : '';
+        $icon = $this->getIcon();
+
+        $tooltip = 'Show details'; //tooltip content
+
+        if ($href = $this->href()) {
+            return "<a href='{$href}' class='{$linkClass}' title='{$tooltip}'>{$icon}<span class='label'>{$this->name()}</span></a>";
+        }
+
+        $this->addScript();
+
+        $attributes = $this->formatAttributes();
+
+        return sprintf(
+            "<a data-_key='%s' href='javascript:void(0);' class='%s {$linkClass}' {$attributes} title='{$tooltip}'>{$icon}<span class='label'>%s</span></a>",
+            $this->getKey(),
+            $this->getElementClass(),
+            $this->asColumn ? $this->display($this->row($this->column->getName())) : $this->name()
+        );
+    }
+
 }


### PR DESCRIPTION
Tooltip added on Button Actions of Delete, Edit and Show by emmanpbarrameda

- It defines a PHP class 'Edit.php', 'Show.php' and 'Delete.php' extending RowAction to handle rendering for an edit action in a grid or table interface.
- The render() method constructs the HTML for the action, including a tooltip.
- It generates an <a> tag with the tooltip, icon, and label.